### PR TITLE
fix(plumesign): archive signed IPA output

### DIFF
--- a/apps/plumesign/src/commands/sign.rs
+++ b/apps/plumesign/src/commands/sign.rs
@@ -199,7 +199,7 @@ pub async fn execute(args: SignArgs) -> Result<()> {
 
     if let Some(pkg) = package {
         if let Some(output_path) = args.output {
-            let archived_path = pkg.get_archive_based_on_path(&args.package.clone())?;
+            let archived_path = pkg.get_archive_based_on_path(&bundle.bundle_dir())?;
             tokio::fs::copy(&archived_path, &output_path).await?;
             log::info!("Saved signed package to: {}", output_path.display());
             if std::env::var("PLUME_DELETE_AFTER_FINISHED").is_err() {

--- a/crates/plume_utils/src/package.rs
+++ b/crates/plume_utils/src/package.rs
@@ -205,7 +205,7 @@ impl Package {
                     .strip_prefix(prefix)
                     .map_err(|_| Error::PackageInfoPlistMissing)?
                     .to_string_lossy()
-                    .to_string();
+                    .replace('\\', "/");
 
                 if entry_path.is_file() {
                     zip.start_file(&name, options.clone())?;


### PR DESCRIPTION
## Summary

- archive the signed staging bundle instead of copying the original IPA
- normalize ZIP entry separators to `/` on Windows

The separator normalization is required because this fix makes `plumesign` rebuild the IPA from the signed staging directory. On Windows, those ZIP entries would otherwise contain `\`, which is not valid for IPA paths.

## Testing

Tested on Windows only.

- [x] `cargo check -p plumesign -p plumeimpactor`
- [x] Signed an unsigned IPA with a saved Apple ID account
- [x] Verified the output differs from the original IPA
- [x] Verified `_CodeSignature` and `embedded.mobileprovision` are included
- [x] Verified all ZIP entries use `/`
- [x] Installed the resulting IPA on an iPhone 15 Pro

Fixes #229